### PR TITLE
Image navigation

### DIFF
--- a/client/src/ProductView/ProductImage.jsx
+++ b/client/src/ProductView/ProductImage.jsx
@@ -88,7 +88,6 @@ const ProductImage = (props) => {
                   aria-hidden="true"
                   onClick={() => handleArrowClick('right')} ></i>
           }
-
         </Col>
       </Row>
     </Col>

--- a/client/src/ProductView/ProductImage.jsx
+++ b/client/src/ProductView/ProductImage.jsx
@@ -6,6 +6,8 @@ import ProductThumbnails from './ProductThumbnails.jsx';
 
 const ProductImage = (props) => {
   const [currentImage, setCurrentImage] = useState(0);
+  const [firstImage, setFirstImage] = useState(true);
+  const [lastImage, setLastImage] = useState(false);
 
   const removeActiveClass = (e) => {
     let thumbnails = document.querySelectorAll('.thumbnail');
@@ -23,10 +25,25 @@ const ProductImage = (props) => {
   };
 
   const handleArrowClick = (direction) => {
+    let lastImage = props.productStyle.photos.length - 2;
+
     if (direction === 'right') {
-      setCurrentImage(currentImage + 1)
-    } else {
-      setCurrentImage(currentImage - 1)
+      if(currentImage === lastImage) {
+        setLastImage(true);
+      }
+      if (!!lastImage) {
+        setCurrentImage(currentImage + 1);
+        setFirstImage(false);
+      }
+    }
+    if (direction === 'left') {
+      if(currentImage === 1) {
+        setFirstImage(true);
+      }
+      if (!!firstImage) {
+        setCurrentImage(currentImage - 1);
+        setLastImage(false);
+      }
     };
   };
 
@@ -40,10 +57,13 @@ const ProductImage = (props) => {
         </Col>
 
         <Col sm={10} className="mainImage fluid">
-          <i className="fa fa-arrow-left"
-            aria-hidden="true"
-            onClick={() => handleArrowClick('left')} ></i>
-
+          { firstImage
+              ? ''
+              : <i
+                  className="fa fa-arrow-left"
+                  aria-hidden="true"
+                  onClick={() => handleArrowClick('left')} ></i>
+          }
           { props.productStyle
             ? <ReactImageMagnify {...{
                 smallImage: {
@@ -61,11 +81,14 @@ const ProductImage = (props) => {
               }} />
             : <p>Loading...</p>
           }
+          { lastImage
+              ? ''
+              : <i
+                  className="fa fa-arrow-right"
+                  aria-hidden="true"
+                  onClick={() => handleArrowClick('right')} ></i>
+          }
 
-          <i
-            className="fa fa-arrow-right"
-            aria-hidden="true"
-            onClick={() => handleArrowClick('right')} ></i>
         </Col>
       </Row>
     </Col>

--- a/client/src/ProductView/ProductThumbnails.jsx
+++ b/client/src/ProductView/ProductThumbnails.jsx
@@ -5,9 +5,15 @@ import Col from 'react-bootstrap/Col';
 const ProductThumbnails = (props) => {
   let thumbnailsArrow = false;
 
-  const handleThumbnailArrowClick = () => {
+  const handleThumbnailArrowClick = (direction) => {
     let thumbnailContainer = document.querySelector('.thumbnails');
-    thumbnailContainer.scrollTo({ top: 600, behavior: 'smooth' })
+    if (direction === 'down') {
+      thumbnailContainer.scrollTo({ top: 600, behavior: 'smooth' });
+    }
+    if (direction === 'up') {
+      thumbnailContainer.scrollTo({ top: -600, behavior: 'smooth' });
+    }
+
   };
 
   return (
@@ -28,11 +34,15 @@ const ProductThumbnails = (props) => {
           : <p>Loading...</p>
         }
       </div>
-
       { thumbnailsArrow
-        ? <p className="arrow" onClick={handleThumbnailArrowClick}>
-            <i className="fa fa-angle-down" aria-hidden="true"></i>
-          </p>
+        ? <div className="thumbnail-nav">
+            <p className="arrow arrow-up" onClick={() => handleThumbnailArrowClick('up')}>
+              <i className="fa fa-angle-up" aria-hidden="true"></i>
+            </p>
+            <p className="arrow arrow-down" onClick={() => handleThumbnailArrowClick('down')}>
+              <i className="fa fa-angle-down" aria-hidden="true"></i>
+            </p>
+          </div>
         : ''
       }
     </div>

--- a/client/src/ProductView/ProductThumbnails.jsx
+++ b/client/src/ProductView/ProductThumbnails.jsx
@@ -31,7 +31,7 @@ const ProductThumbnails = (props) => {
 
       { thumbnailsArrow
         ? <p className="arrow" onClick={handleThumbnailArrowClick}>
-            <i className="fa fa-arrow-circle-o-down" aria-hidden="true"></i>
+            <i className="fa fa-angle-down" aria-hidden="true"></i>
           </p>
         : ''
       }

--- a/client/src/ProductView/ProductView.css
+++ b/client/src/ProductView/ProductView.css
@@ -1,6 +1,9 @@
 .align-right {
   text-align: right;
 }
+.productViewRow {
+  overflow-y: hidden;
+}
 .productDetails .category {
   text-transform: uppercase;
 }

--- a/client/src/ProductView/ProductView.css
+++ b/client/src/ProductView/ProductView.css
@@ -2,7 +2,7 @@
   text-align: right;
 }
 .productViewRow {
-  overflow-y: hidden;
+  overflow-x: hidden;
 }
 .productDetails .category {
   text-transform: uppercase;

--- a/client/src/ProductView/ProductView.css
+++ b/client/src/ProductView/ProductView.css
@@ -67,16 +67,22 @@ p.currentStyle {
   height: 500px;
 }
 .thumbnails {
-  height: 490px;
+  height: 500px;
   overflow: hidden;
+  margin-top: 15px;
 }
 .imageContainer .arrow {
   position: absolute;
-  bottom: 0;
-  left: 34px;
+  left: 37px;
   font-size: 25px;
-  margin-bottom: -17px;
   margin-left: 18px;
+}
+.imageContainer .arrow-down {
+  bottom: 0;
+  margin-bottom: -17px;
+}
+.imageContainer .arrow-up {
+  top: -15px;
 }
 .productDescription {
   margin-top: 40px;
@@ -88,6 +94,9 @@ p.currentStyle {
   background: transparent;
   border: none;
   border-bottom: 2px solid #fff;
+}
+.mainImage {
+  margin: 15px 0;
 }
 .mainImage img {
   position: relative;

--- a/client/src/ProductView/ProductView.jsx
+++ b/client/src/ProductView/ProductView.jsx
@@ -15,7 +15,7 @@ const ProductView = (props) => {
       : '';
 
   return (
-    <Row>
+    <Row className="productViewRow">
       <ProductImage productStyle={productStyleResult} />
       <ProductDetailsColumn
         details={props.productData}


### PR DESCRIPTION
Here's the ticket associated with these changes: https://trello.com/c/r5ZdNbAw/90-create-scrolling-functionality-for-product-images
I added arrows to the main image, and made it so that when the user is on the first image, they won't see the left arrow, and if they are on the last image, the won't see the right arrow. I also added both up and down arrows to the thumbnails so the user can scroll through when there are more than 7 thumbnails.